### PR TITLE
regex getopt

### DIFF
--- a/vanity.hpp
+++ b/vanity.hpp
@@ -39,7 +39,7 @@
 	W[i] + k)
 
 
-static i2p::data::SigningKeyType type;
+//static i2p::data::SigningKeyType type;
 //static i2p::data::PrivateKeys keys;
 static bool found=false;
 

--- a/vanitygen.cpp
+++ b/vanitygen.cpp
@@ -288,7 +288,7 @@ int main (int argc, char * argv[])
 		usaging();
 		return 0;
 	}
-	parsing(argc-1, argv+1);
+	parsing( argc > 2 ? argc-1 : argc, argc > 2 ? argv+1 : argv);
 	//
 	if(!options.reg && !check_prefix( argv[1] ))
 	{


### PR DESCRIPTION
regex getopt

```lock@lock-pc ~/regex/i2pd-tools $ ./vain -h
vain pattern [options]
-h --help help menu
-r --reg  regexp instead just text pattern
--threads -t (default count of system)
--signature -s (signature type)
-o --output output file(default private.dat)
--usage usaging
--prefix -p

lock@lock-pc ~/regex/i2pd-tools $ ./vain some -t 5
Start vanity generator in 5 threads
Thread 4 binded
Thread 3 binded
Thread 0 binded
Thread 2 binded
Thread 1 binded
Address found some3chyrjqcdsxvv6cwagc2bnioupib3uhtldmvvmvjo5isn5wq in 0
Hashes: 1991693

lock@lock-pc ~/regex/i2pd-tools $ ./vain ^[a-z][0-9].*zzz$ -r
Start vanity generator in 4 threads
Thread 3 binded
Thread Thread 1 binded
Thread 0 binded
2 binded
Address found i7ry4jokojbcx6zzz5ukjocy65idttgnvcqezti3bvrilub4jlga in 2
Hashes: 419077

lock@lock-pc ~/regex/i2pd-tools $ ./vain ss -o so.dat
Start vanity generator in 4 threads
Thread 2 binded
Thread 0 binded
Thread 3 binded
Thread 1 binded
Address found ss7wgs7wtokblgl3xmsf2bnsfgg3ruxqfux4e47vbi3ammskggma in 0
Hashes: 133
lock@lock-pc ~/regex/i2pd-tools $ ls so.dat
so.dat

etc
