### PR TITLE
Print usage() when pattern is invalid

### DIFF
--- a/vanitygen.cpp
+++ b/vanitygen.cpp
@@ -287,7 +287,8 @@ int main (int argc, char * argv[])
 	//
 	if(!options.reg && !check_prefix( argv[1] ))
 	{
-		std::cout << "Not correct prefix(just string)" << std::endl;
+		std::cout << "Invalid pattern." << std::endl;
+		usage();
 		return 1;
 	}else{
 		options.regex=std::regex(argv[1]);


### PR DESCRIPTION
I ran into this for like half an hour before I figured out I needed to run `vain pattern opts` instead of `vain opts pattern`. Printing `usage()` here to help others in the future.