### PR TITLE
Improve `vain` output format and instructions

### DIFF
--- a/vanity.hpp
+++ b/vanity.hpp
@@ -38,6 +38,8 @@
 	S[(70 - i) % 8], S[(71 - i) % 8], \
 	W[i] + k)
 
+#define DEF_OUTNAME "private.dat"
+
 
 //static i2p::data::SigningKeyType type;
 //static i2p::data::PrivateKeys keys;


### PR DESCRIPTION
- Clarify usage and instructions, add better examples
- Move hardcoded defaults to vanity.hpp definitions
- Fix typos (e.g., binded => bound) and make output look nicer
