### PR TITLE
scan entire string when using regex

### DIFF
--- a/vanitygen.cpp
+++ b/vanitygen.cpp
@@ -162,7 +162,11 @@ static inline bool thread_find(uint8_t * buf, const char * prefix, int id_thread
 
 	memcpy (b, buf, 391);
 
-	auto len = strlen (prefix);
+	size_t len = 52;
+	
+	if (!options.reg)
+		len = strlen(prefix);
+
 	// precalculate first 5 blocks (320 bytes)
 	uint32_t state[8] = { 0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19 };
 	HashNextBlock (state, b);


### PR DESCRIPTION
len variable would only scan the length of the regex string. this means if you were to use the regex expression .*i2p$ it would generate btbi2pxm5xi4zh32ye5emeq5koqbdd2gywxmpzjpaivpf744bcka instead of btbckaxm5xi4zh32ye5emeq5koqbdd2gywxmpzjpaivpf744bi2p