### PR TITLE
Force dynamic linking with Boost Filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ INCFLAGS = -I$(LIBI2PD_PATH) -I$(LIBI2PD_CLIENT_PATH)
 DEFINES = -DOPENSSL_SUPPRESS_DEPRECATED
 
 LDFLAGS = 
-LDLIBS = $(I2PD_PATH)/$(I2PD_LIB) -lboost_system$(BOOST_SUFFIX) -lboost_program_options$(BOOST_SUFFIX) -lssl -lcrypto -lz 
+LDLIBS = $(I2PD_PATH)/$(I2PD_LIB) -lboost_system$(BOOST_SUFFIX) -lboost_program_options$(BOOST_SUFFIX) -lboost_filesystem$(BOOST_SUFFIX) -lssl -lcrypto -lz
 
 
 ifeq ($(UNAME),Linux)


### PR DESCRIPTION
Updated the Makefile to dynamically link the Boost Filesystem library by adding the `-lboost_filesystem` option to the `LDLIBS` variable. This change fixes undefined reference errors encountered during compilation on Devuan 5 (based on Debian 12), where certain Boost Filesystem functions were not found by the linker (ld) even though the required library was installed.