### PR TITLE
Add i2pbox to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,8 @@ A program for help create the config file for i2pd
 For a now a better way to manual write the config file
 
 For usage just run ./AutoConf or AutoConf.exe
+
+
+## Related Projects
+
+[i2pbox](https://github.com/iasds/i2pbox) — all i2pd-tools merged into a single binary with subcommands.


### PR DESCRIPTION
Adds a link to [i2pbox](https://github.com/iasds/i2pbox) — a unified wrapper that merges all 14 i2pd-tools into a single binary.

See discussion: https://github.com/PurpleI2P/i2pd-tools/issues/120